### PR TITLE
Add better set handling... not ready yet for merge

### DIFF
--- a/pyagentx3/agent.py
+++ b/pyagentx3/agent.py
@@ -56,7 +56,6 @@ class Agent():
         except ValueError:
             raise AgentError('OID isn\'t valid')
         self._sethandlers[oid] = class_(data_store=data_store)
-        self._sethandlers[oid].agent_setup(oid)
 
     def setup(self):
         # Override this
@@ -73,6 +72,11 @@ class Agent():
             thread.agent_setup(queue, u['oid'], u['freq'])
             thread.start()
             self._threads.append(thread)
+
+        # Setup SetHandlers
+        for oid in self._sethandlers:
+            logger.debug('Initializing sethandler [%s]', oid)
+            self._sethandlers[oid].agent_setup(queue, oid)
 
         # Start Network
         oid_list = [u['oid'] for u in self._updater_list]

--- a/pyagentx3/agent.py
+++ b/pyagentx3/agent.py
@@ -56,6 +56,7 @@ class Agent():
         except ValueError:
             raise AgentError('OID isn\'t valid')
         self._sethandlers[oid] = class_(data_store=data_store)
+        self._sethandlers[oid].agent_setup(oid)
 
     def setup(self):
         # Override this

--- a/pyagentx3/network.py
+++ b/pyagentx3/network.py
@@ -196,7 +196,10 @@ class Network(threading.Thread):
 
             response = self.response_pdu(request)
             if request.type == pyagentx3.AGENTX_GET_PDU:
-                logger.info("Received GET PDU")
+                toid = ""
+                if request.range_list:
+                    toid = request.range_list[0][0]
+                logger.info("Received GET PDU: " + str(toid))
                 for rvalue in request.range_list:
                     oid = rvalue[0]
                     logger.debug("OID: %s", oid)

--- a/pyagentx3/pdu.py
+++ b/pyagentx3/pdu.py
@@ -89,7 +89,7 @@ class PDU(object):
 
         buf += bytearray(data)
 
-        padding = (4 - (data_len % 4)) % 4
+        padding = -data_len % 4
         buf += bytearray([0] * padding)
         return buf
 
@@ -229,7 +229,7 @@ class PDU(object):
             buf = b''
             self.decode_buf = self.decode_buf[4:]
             if l > 0:
-                padding = 4 - (l % 4)
+                padding = -l % 4
                 buf = self.decode_buf[:l]
                 self.decode_buf = self.decode_buf[l+padding:]
             return buf

--- a/pyagentx3/sethandler.py
+++ b/pyagentx3/sethandler.py
@@ -10,6 +10,11 @@ logger.addHandler(NullHandler())
 # --------------------------------------------
 
 
+from queue import Full
+
+import pyagentx3
+
+
 class SetHandlerError(Exception):
     pass
 
@@ -21,9 +26,12 @@ class SetHandler():
         # A map of transactions to varbinds
         self.transactions = {}
         self._oid = None
+        self._data = {}
 
-    def agent_setup(self, oid):
+    def agent_setup(self, queue, oid):
+        self._queue = queue
         self._oid = oid
+        self._data = {}
 
     def network_test(self, session_id, transaction_id, oid, data):
         tid = "%s_%s" % (session_id, transaction_id)
@@ -50,9 +58,14 @@ class SetHandler():
         tid = "%s_%s" % (session_id, transaction_id)
         if tid not in self.transactions:
             return
+        self._data = {}
         try:
             self.commit(tid, self.transactions[tid])
             del self.transactions[tid]
+            self._queue.put_nowait({'oid': self._oid,
+                                    'data': self._data})
+        except Full:
+            logger.error('Queue full')
         except Exception as e:
             logger.error('CommitSet failed: %s', e)
 
@@ -78,3 +91,18 @@ class SetHandler():
     def commit(self, tid, oid, data):
         pass
 
+    def set_INTEGER(self, oid, value):
+        logger.debug('Setting INTEGER %s = %s', oid, value)
+        self._data[oid] = self._INTEGER(oid, value)
+
+    def set_OCTETSTRING(self, oid, value):
+        logger.debug('Setting OCTETSTRING %s = %s', oid, value)
+        self._data[oid] = self._OCTETSTRING(oid, value)
+
+    @staticmethod
+    def _INTEGER(oid, value):
+        return {'name': oid, 'type':pyagentx3.TYPE_INTEGER, 'value':value}
+
+    @staticmethod
+    def _OCTETSTRING(oid, value):
+        return {'name': oid, 'type':pyagentx3.TYPE_OCTETSTRING, 'value':value}

--- a/pyagentx3/sethandler.py
+++ b/pyagentx3/sethandler.py
@@ -18,15 +18,32 @@ class SetHandler():
 
     def __init__(self, data_store=None):
         self.data_store = data_store
+        # A map of transactions to varbinds
         self.transactions = {}
+        self._oid = None
+
+    def agent_setup(self, oid):
+        self._oid = oid
 
     def network_test(self, session_id, transaction_id, oid, data):
         tid = "%s_%s" % (session_id, transaction_id)
-        if tid in self.transactions:
-            del self.transactions[tid]
+        if tid not in self.transactions:
+            self.transactions[tid] = []
         try:
-            self.test(oid, data)
-            self.transactions[tid] = oid, data
+            # strip off leading oid
+            oid = oid[len(self._oid) + 1:]
+            self.test(tid, oid, data)
+            self.transactions[tid].append((oid, data))
+        except SetHandlerError as e:
+            logger.error('TestSet failed: %s', e)
+            raise e
+
+    def network_testset(self, session_id, transaction_id):
+        tid = "%s_%s" % (session_id, transaction_id)
+        try:
+            # strip off leading oid
+            oid = oid[len(self._oid) + 1:]
+            self.testset(tid, self.transactions[tid])
         except SetHandlerError as e:
             logger.error('TestSet failed: %s', e)
             raise e
@@ -36,10 +53,8 @@ class SetHandler():
         if tid not in self.transactions:
             return
         try:
-            oid, data = self.transactions[tid]
-            self.commit(oid, data)
-            if tid in self.transactions:
-                del self.transactions[tid]
+            self.commit(tid, self.transactions[tid])
+            del self.transactions[tid]
         except Exception as e:
             logger.error('CommitSet failed: %s', e)
 
@@ -54,9 +69,14 @@ class SetHandler():
             del self.transactions[tid]
 
     # User override these
-    def test(self, oid, data):
+    def test(self, tid, oid, data):
+        """Test individual varbinds in a transaction."""
         pass
 
-    def commit(self, oid, data):
+    def testset(self, tid):
+        """Test whole set after all varbinds have been tested."""
+        pass
+
+    def commit(self, tid, oid, data):
         pass
 

--- a/pyagentx3/sethandler.py
+++ b/pyagentx3/sethandler.py
@@ -41,8 +41,6 @@ class SetHandler():
     def network_testset(self, session_id, transaction_id):
         tid = "%s_%s" % (session_id, transaction_id)
         try:
-            # strip off leading oid
-            oid = oid[len(self._oid) + 1:]
             self.testset(tid, self.transactions[tid])
         except SetHandlerError as e:
             logger.error('TestSet failed: %s', e)


### PR DESCRIPTION
I'd like feedback on this before I continue working on it. I used this package to implement a v2c table. I needed to be able to confirm that all fields for a row were passed for a createAndGo(4) RowStatus. I added a `testset()` method to set handlers that is called at the end of all of the `test()` calls. Additional changes allow setters to make changes to the data used by GET just like the updaters. The lack of link between setters and updaters was a problem for me because a GET after a SET would not reflect the new value until the next scheduled run of the updater. This caused managers to think that the agent was malfunctioning.

Done:

- Add the ability to update the GET data storage from setters as well as updaters
- Add the ability to approve not only individual OIDs but the entire set PDU as a whole by calling each set handler used for a PDU one last time with the entire set of OIDs and data for the PDU
- Fix octet string padding calculation using `-N % D` which gives the inverse of `N % D` and correctly handles `N % D == 0`
- Add first OID to GET log message for easier debugging at reduced log levels
- Trim OIDs sent to setters to be short like in the updaters for a common pattern
- Save all OIDs and results for each OID in a set pdu

TODO:

- Update docs
- Update examples
- Add an example to show how to use common code between updater and setter
- Perhaps increase the queue size. 20 is small if multiple rows are created in a table.
- Add a helper for managing v2c tables (separate pull request after this one)
- squash commits