### PR TITLE
Avoid_unkilled_network_issue

### DIFF
--- a/pyagentx3/agent.py
+++ b/pyagentx3/agent.py
@@ -90,5 +90,5 @@ class Agent():
             thread.stop.set()
         logger.debug('Wait for updater')
         for thread in self._threads:
-            thread.join()
+            thread.join(10)
 

--- a/pyagentx3/network.py
+++ b/pyagentx3/network.py
@@ -154,7 +154,7 @@ class Network(threading.Thread):
         return None # No match!
 
     def start(self):
-        while True:
+        while not self.stop.is_set():
             try:
                 self._start_network()
             except socket.error:
@@ -188,8 +188,10 @@ class Network(threading.Thread):
                 self._get_updates()
                 request = self.recv_pdu()
             except socket.timeout:
+                if self.stop.is_set():
+                    break
                 continue
-
+            
             if not request:
                 logger.error("Empty PDU, connection closed!")
                 raise socket.error


### PR DESCRIPTION
There are some "while True :" lines in the Network.py that may cause issues when we try to kill the thread of the network.

by changing the "while True" loop for a "while not self.stop.is_set()", the loop will end when we try to kill the tread.

By the way i changed the stop method of the agent to add a timeout on the thread.join() => thread.join(10) in order to not be stuck if there is a thread we can't kill for any reason