### PR TITLE
change while True for while not self.stop.is_set() to not keep thread…

### DIFF
--- a/pyagentx3/network.py
+++ b/pyagentx3/network.py
@@ -39,7 +39,7 @@ class Network(threading.Thread):
         self.socket = None
 
     def _connect(self):
-        while True:
+        while not self.stop.is_set():
             try:
                 logger.info("Try to open socket on ({})".format(self._socket_path))
                 self.socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
@@ -119,7 +119,7 @@ class Network(threading.Thread):
     # =========================================
 
     def _get_updates(self):
-        while True:
+        while not self.stop.is_set():
             try:
                 item = self._queue.get_nowait()
                 #logger.info('Update: {}'.format(item))
@@ -219,7 +219,7 @@ class Network(threading.Thread):
             pdu = self.recv_pdu()
 
         logger.info("==== Waiting for PDU ====")
-        while True:
+        while not self.stop.is_set():
             try:
                 self._get_updates()
                 request = self.recv_pdu()

--- a/pyagentx3/updater.py
+++ b/pyagentx3/updater.py
@@ -38,7 +38,7 @@ class Updater(threading.Thread):
 
     def run(self):
         start_time = 0
-        while self.stop.is_set():
+        while not self.stop.is_set():
             now = time.time()
             if now - start_time > self._freq:
                 logger.info('Updating : %s (%s)', self.__class__.__name__, self._oid)

--- a/pyagentx3/updater.py
+++ b/pyagentx3/updater.py
@@ -38,9 +38,7 @@ class Updater(threading.Thread):
 
     def run(self):
         start_time = 0
-        while True:
-            if self.stop.is_set():
-                break
+        while self.stop.is_set():
             now = time.time()
             if now - start_time > self._freq:
                 logger.info('Updating : %s (%s)', self.__class__.__name__, self._oid)


### PR DESCRIPTION
When i tried to stop threads with the Agent's stop method, the thread.join(10) is called.
However a "join" blocks the thread until it ends, and adding a timeout in parameters will allows to blocks until it ends OR until the timeout.
The different  "While True" in Network.py will keep threads alive even when we "thread.stop.set()" and "thread.join(timeout)"
Be careful there is another "while True" in the agent, maybe you should change it